### PR TITLE
Update requirements

### DIFF
--- a/requirements
+++ b/requirements
@@ -2,3 +2,4 @@ python-whois
 futures
 requests
 lxml
+urllib3[secure]


### PR DESCRIPTION
i got this problem when running on https sites

/usr/local/lib/python2.7/dist-packages/urllib3-dev-py2.7.egg/urllib3/connectionpool.py:858: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
 and thats the solution